### PR TITLE
Add uniques pallet chain extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7535,9 +7535,9 @@ dependencies = [
  "log",
  "nfts-chain-extension-types",
  "num-traits",
- "pallet-assets",
  "pallet-contracts",
  "pallet-contracts-primitives",
+ "pallet-uniques",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
@@ -8791,6 +8791,21 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-uniques"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.43#5e49f6e44820affccaf517fd22af564f4b495d40"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
  "sp-runtime",
  "sp-std",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6825,6 +6825,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nfts-chain-extension-types"
+version = "0.1.0"
+dependencies = [
+ "frame-system",
+ "pallet-contracts",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+]
+
+[[package]]
 name = "nix"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7508,6 +7519,25 @@ dependencies = [
  "pallet-contracts",
  "pallet-contracts-primitives",
  "pallet-dapps-staking",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-chain-extension-nfts"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "log",
+ "nfts-chain-extension-types",
+ "num-traits",
+ "pallet-assets",
+ "pallet-contracts",
+ "pallet-contracts-primitives",
  "parity-scale-codec",
  "scale-info",
  "sp-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,7 @@ frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", bran
 # Substrate pallets
 # (wasm)
 pallet-assets = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43", default-features = false }
+pallet-uniques = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43", default-features = false }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43", default-features = false }
 pallet-proxy = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43", default-features = false }
 pallet-utility = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.43", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
 
 	"chain-extensions/dapps-staking",
 	"chain-extensions/pallet-assets",
+	"chain-extensions/pallet-nfts",
 	"chain-extensions/xvm",
 	"chain-extensions/unified-accounts",
 	"chain-extensions/types/*",
@@ -295,11 +296,13 @@ pallet-evm-precompile-dapps-staking = { path = "./precompiles/dapps-staking", de
 pallet-chain-extension-dapps-staking = { path = "./chain-extensions/dapps-staking", default-features = false }
 pallet-chain-extension-xvm = { path = "./chain-extensions/xvm", default-features = false }
 pallet-chain-extension-assets = { path = "./chain-extensions/pallet-assets", default-features = false }
+pallet-chain-extension-nfts = { path = "./chain-extensions/pallet-nfts", default-features = false }
 pallet-chain-extension-unified-accounts = { path = "./chain-extensions/unified-accounts", default-features = false }
 
 dapps-staking-chain-extension-types = { path = "./chain-extensions/types/dapps-staking", default-features = false }
 xvm-chain-extension-types = { path = "./chain-extensions/types/xvm", default-features = false }
 assets-chain-extension-types = { path = "./chain-extensions/types/assets", default-features = false }
+nfts-chain-extension-types = { path = "./chain-extensions/types/nfts", default-features = false }
 unified-accounts-chain-extension-types = { path = "./chain-extensions/types/unified-accounts", default-features = false }
 
 precompile-utils = { path = "./precompiles/utils", default-features = false }

--- a/chain-extensions/pallet-nfts/Cargo.toml
+++ b/chain-extensions/pallet-nfts/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "pallet-chain-extension-nfts"
+version = "0.1.0"
+license = "Apache-2.0"
+description = "Assets chain extension for WASM contracts"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+nfts-chain-extension-types = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+log = { workspace = true }
+num-traits = { workspace = true }
+pallet-assets = { workspace = true }
+pallet-contracts = { workspace = true }
+pallet-contracts-primitives = { workspace = true }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+	"parity-scale-codec/std",
+	"frame-support/std",
+	"frame-system/std",
+	"num-traits/std",
+	"pallet-contracts/std",
+	"pallet-contracts-primitives/std",
+	"scale-info/std",
+	"sp-std/std",
+	"sp-core/std",
+	"sp-runtime/std",
+	"pallet-assets/std",
+	"nfts-chain-extension-types/std",
+]

--- a/chain-extensions/pallet-nfts/Cargo.toml
+++ b/chain-extensions/pallet-nfts/Cargo.toml
@@ -14,7 +14,7 @@ frame-support = { workspace = true }
 frame-system = { workspace = true }
 log = { workspace = true }
 num-traits = { workspace = true }
-pallet-assets = { workspace = true }
+pallet-uniques = { workspace = true }
 pallet-contracts = { workspace = true }
 pallet-contracts-primitives = { workspace = true }
 parity-scale-codec = { workspace = true }
@@ -36,6 +36,6 @@ std = [
 	"sp-std/std",
 	"sp-core/std",
 	"sp-runtime/std",
-	"pallet-assets/std",
+	"pallet-uniques/std",
 	"nfts-chain-extension-types/std",
 ]

--- a/chain-extensions/pallet-nfts/src/lib.rs
+++ b/chain-extensions/pallet-nfts/src/lib.rs
@@ -26,7 +26,7 @@ use frame_support::traits::{
     fungibles::metadata::Inspect as MetadataInspect,
 };
 use frame_system::RawOrigin;
-use pallet_assets::WeightInfo;
+use pallet_uniques::WeightInfo;
 use pallet_contracts::chain_extension::{
     ChainExtension, Environment, Ext, InitState, RetVal, SysConfig,
 };
@@ -109,20 +109,18 @@ impl TryFrom<u16> for NftsFunc {
     }
 }
 
-/*
-/// Pallet Assets chain extension.
-pub struct AssetsExtension<T, W>(PhantomData<(T, W)>);
+/// Pallet Nfts chain extension.
+pub struct NftsExtension<T, W>(PhantomData<(T, W)>);
 
-impl<T, W> Default for AssetsExtension<T, W> {
+impl<T, W> Default for NftsExtension<T, W> {
     fn default() -> Self {
-        AssetsExtension(PhantomData)
+        NftsExtension(PhantomData)
     }
 }
 
-impl<T, W> ChainExtension<T> for AssetsExtension<T, W>
+impl<T, W> ChainExtension<T> for NftsExtension<T, W>
 where
-    T: pallet_assets::Config + pallet_contracts::Config,
-    <T as pallet_assets::Config>::AssetId: Copy,
+    T: pallet_uniques::Config + pallet_contracts::Config,
     <<T as SysConfig>::Lookup as StaticLookup>::Source: From<<T as SysConfig>::AccountId>,
     <T as SysConfig>::AccountId: From<[u8; 32]>,
     W: weights::WeightInfo,
@@ -135,25 +133,21 @@ where
         let mut env = env.buf_in_buf_out();
 
         match func_id {
-            AssetsFunc::Create => {
-                let (origin, id, admin, min_balance): (
+            NftsFunc::Create => {
+                let (origin, collection_id, admin): (
                     Origin,
-                    <T as pallet_assets::Config>::AssetId,
+                    <T as pallet_uniques::Config>::CollectionId,
                     T::AccountId,
-                    T::Balance,
                 ) = env.read_as()?;
-
-                let base_weight = <T as pallet_assets::Config>::WeightInfo::create();
-                env.charge_weight(base_weight)?;
 
                 let raw_origin = select_origin!(&origin, env.ext().address().clone());
 
-                let call_result = pallet_assets::Pallet::<T>::create(
+                let call_result = pallet_uniques::Pallet::<T>::create(
                     raw_origin.into(),
-                    id.into(),
+                    collection_id.into(),
                     admin.into(),
-                    min_balance,
                 );
+
                 return match call_result {
                     Err(e) => {
                         let mapped_error = Outcome::from(e);
@@ -161,288 +155,10 @@ where
                     }
                     Ok(_) => Ok(RetVal::Converging(Outcome::Success as u32)),
                 };
-            }
-            AssetsFunc::Transfer => {
-                let (origin, id, target, amount): (
-                    Origin,
-                    <T as pallet_assets::Config>::AssetId,
-                    T::AccountId,
-                    T::Balance,
-                ) = env.read_as()?;
-
-                let base_weight = <T as pallet_assets::Config>::WeightInfo::transfer();
-                env.charge_weight(base_weight)?;
-
-                let raw_origin = select_origin!(&origin, env.ext().address().clone());
-
-                let call_result = pallet_assets::Pallet::<T>::transfer(
-                    raw_origin.into(),
-                    id.into(),
-                    target.into(),
-                    amount,
-                );
-                return match call_result {
-                    Err(e) => {
-                        let mapped_error = Outcome::from(e);
-                        Ok(RetVal::Converging(mapped_error as u32))
-                    }
-                    Ok(_) => Ok(RetVal::Converging(Outcome::Success as u32)),
-                };
-            }
-            AssetsFunc::Mint => {
-                let (origin, id, beneficiary, amount): (
-                    Origin,
-                    <T as pallet_assets::Config>::AssetId,
-                    T::AccountId,
-                    T::Balance,
-                ) = env.read_as()?;
-
-                let base_weight = <T as pallet_assets::Config>::WeightInfo::mint();
-                env.charge_weight(base_weight)?;
-
-                let raw_origin = select_origin!(&origin, env.ext().address().clone());
-
-                let call_result = pallet_assets::Pallet::<T>::mint(
-                    raw_origin.into(),
-                    id.into(),
-                    beneficiary.into(),
-                    amount,
-                );
-                return match call_result {
-                    Err(e) => {
-                        let mapped_error = Outcome::from(e);
-                        Ok(RetVal::Converging(mapped_error as u32))
-                    }
-                    Ok(_) => Ok(RetVal::Converging(Outcome::Success as u32)),
-                };
-            }
-            AssetsFunc::Burn => {
-                let (origin, id, who, amount): (
-                    Origin,
-                    <T as pallet_assets::Config>::AssetId,
-                    T::AccountId,
-                    T::Balance,
-                ) = env.read_as()?;
-
-                let base_weight = <T as pallet_assets::Config>::WeightInfo::burn();
-                env.charge_weight(base_weight)?;
-
-                let raw_origin = select_origin!(&origin, env.ext().address().clone());
-
-                let call_result = pallet_assets::Pallet::<T>::burn(
-                    raw_origin.into(),
-                    id.into(),
-                    who.into(),
-                    amount,
-                );
-                return match call_result {
-                    Err(e) => {
-                        let mapped_error = Outcome::from(e);
-                        Ok(RetVal::Converging(mapped_error as u32))
-                    }
-                    Ok(_) => Ok(RetVal::Converging(Outcome::Success as u32)),
-                };
-            }
-            AssetsFunc::BalanceOf => {
-                let (id, who): (<T as pallet_assets::Config>::AssetId, T::AccountId) =
-                    env.read_as()?;
-
-                let base_weight = <W as weights::WeightInfo>::balance_of();
-                env.charge_weight(base_weight)?;
-
-                let balance = pallet_assets::Pallet::<T>::balance(id, who);
-                env.write(&balance.encode(), false, None)?;
-            }
-            AssetsFunc::TotalSupply => {
-                let id: <T as pallet_assets::Config>::AssetId = env.read_as()?;
-
-                let base_weight = <W as weights::WeightInfo>::total_supply();
-                env.charge_weight(base_weight)?;
-
-                let total_supply = pallet_assets::Pallet::<T>::total_supply(id);
-                env.write(&total_supply.encode(), false, None)?;
-            }
-            AssetsFunc::Allowance => {
-                let (id, owner, delegate): (
-                    <T as pallet_assets::Config>::AssetId,
-                    T::AccountId,
-                    T::AccountId,
-                ) = env.read_as()?;
-
-                let base_weight = <W as weights::WeightInfo>::allowance();
-                env.charge_weight(base_weight)?;
-
-                let allowance = pallet_assets::Pallet::<T>::allowance(id, &owner, &delegate);
-                env.write(&allowance.encode(), false, None)?;
-            }
-            AssetsFunc::ApproveTransfer => {
-                let (origin, id, delegate, amount): (
-                    Origin,
-                    <T as pallet_assets::Config>::AssetId,
-                    T::AccountId,
-                    T::Balance,
-                ) = env.read_as()?;
-
-                let base_weight = <T as pallet_assets::Config>::WeightInfo::approve_transfer();
-                env.charge_weight(base_weight)?;
-
-                let raw_origin = select_origin!(&origin, env.ext().address().clone());
-
-                let call_result = pallet_assets::Pallet::<T>::approve_transfer(
-                    raw_origin.into(),
-                    id.into(),
-                    delegate.into(),
-                    amount,
-                );
-                return match call_result {
-                    Err(e) => {
-                        let mapped_error = Outcome::from(e);
-                        Ok(RetVal::Converging(mapped_error as u32))
-                    }
-                    Ok(_) => Ok(RetVal::Converging(Outcome::Success as u32)),
-                };
-            }
-            AssetsFunc::CancelApproval => {
-                let (origin, id, delegate): (
-                    Origin,
-                    <T as pallet_assets::Config>::AssetId,
-                    T::AccountId,
-                ) = env.read_as()?;
-
-                let base_weight = <T as pallet_assets::Config>::WeightInfo::cancel_approval();
-                env.charge_weight(base_weight)?;
-
-                let raw_origin = select_origin!(&origin, env.ext().address().clone());
-
-                let call_result = pallet_assets::Pallet::<T>::cancel_approval(
-                    raw_origin.into(),
-                    id.into(),
-                    delegate.into(),
-                );
-                return match call_result {
-                    Err(e) => {
-                        let mapped_error = Outcome::from(e);
-                        Ok(RetVal::Converging(mapped_error as u32))
-                    }
-                    Ok(_) => Ok(RetVal::Converging(Outcome::Success as u32)),
-                };
-            }
-            AssetsFunc::TransferApproved => {
-                let (origin, id, owner, destination, amount): (
-                    Origin,
-                    <T as pallet_assets::Config>::AssetId,
-                    T::AccountId,
-                    T::AccountId,
-                    T::Balance,
-                ) = env.read_as()?;
-
-                let base_weight = <T as pallet_assets::Config>::WeightInfo::transfer_approved();
-                env.charge_weight(base_weight)?;
-
-                let raw_origin = select_origin!(&origin, env.ext().address().clone());
-
-                let call_result = pallet_assets::Pallet::<T>::transfer_approved(
-                    raw_origin.into(),
-                    id.into(),
-                    owner.into(),
-                    destination.into(),
-                    amount,
-                );
-                return match call_result {
-                    Err(e) => {
-                        let mapped_error = Outcome::from(e);
-                        Ok(RetVal::Converging(mapped_error as u32))
-                    }
-                    Ok(_) => Ok(RetVal::Converging(Outcome::Success as u32)),
-                };
-            }
-            AssetsFunc::SetMetadata => {
-                let (origin, id, name, symbol, decimals): (
-                    Origin,
-                    <T as pallet_assets::Config>::AssetId,
-                    Vec<u8>,
-                    Vec<u8>,
-                    u8,
-                ) = env.read_as_unbounded(env.in_len())?;
-
-                let base_weight = <T as pallet_assets::Config>::WeightInfo::set_metadata(
-                    name.len() as u32,
-                    symbol.len() as u32,
-                );
-                env.charge_weight(base_weight)?;
-
-                let raw_origin = select_origin!(&origin, env.ext().address().clone());
-
-                let call_result = pallet_assets::Pallet::<T>::set_metadata(
-                    raw_origin.into(),
-                    id.into(),
-                    name,
-                    symbol,
-                    decimals,
-                );
-                return match call_result {
-                    Err(e) => {
-                        let mapped_error = Outcome::from(e);
-                        Ok(RetVal::Converging(mapped_error as u32))
-                    }
-                    Ok(_) => Ok(RetVal::Converging(Outcome::Success as u32)),
-                };
-            }
-            AssetsFunc::MetadataName => {
-                let id: <T as pallet_assets::Config>::AssetId = env.read_as()?;
-
-                let base_weight = <W as weights::WeightInfo>::metadata_name();
-                env.charge_weight(base_weight)?;
-
-                let name = pallet_assets::Pallet::<T>::name(id);
-                env.write(&name.encode(), false, None)?;
-            }
-            AssetsFunc::MetadataSymbol => {
-                let id: <T as pallet_assets::Config>::AssetId = env.read_as()?;
-
-                let base_weight = <W as weights::WeightInfo>::metadata_symbol();
-                env.charge_weight(base_weight)?;
-
-                let symbol = pallet_assets::Pallet::<T>::symbol(id);
-                env.write(&symbol.encode(), false, None)?;
-            }
-            AssetsFunc::MetadataDecimals => {
-                let id: <T as pallet_assets::Config>::AssetId = env.read_as()?;
-
-                let base_weight = <W as weights::WeightInfo>::metadata_decimals();
-                env.charge_weight(base_weight)?;
-
-                let decimals = pallet_assets::Pallet::<T>::decimals(id);
-                env.write(&decimals.encode(), false, None)?;
-            }
-            AssetsFunc::TransferOwnership => {
-                let (origin, id, owner): (
-                    Origin,
-                    <T as pallet_assets::Config>::AssetId,
-                    T::AccountId,
-                ) = env.read_as()?;
-
-                let base_weight = <T as pallet_assets::Config>::WeightInfo::transfer_ownership();
-                env.charge_weight(base_weight)?;
-
-                let raw_origin = select_origin!(&origin, env.ext().address().clone());
-
-                let call_result = pallet_assets::Pallet::<T>::transfer_ownership(
-                    raw_origin.into(),
-                    id.into(),
-                    owner.into(),
-                );
-                return match call_result {
-                    Err(e) => {
-                        let mapped_error = Outcome::from(e);
-                        Ok(RetVal::Converging(mapped_error as u32))
-                    }
-                    Ok(_) => Ok(RetVal::Converging(Outcome::Success as u32)),
-                };
-            }
+            },
+            _ => todo!()
         }
 
         Ok(RetVal::Converging(Outcome::Success as u32))
     }
 }
-*/

--- a/chain-extensions/pallet-nfts/src/lib.rs
+++ b/chain-extensions/pallet-nfts/src/lib.rs
@@ -1,0 +1,448 @@
+// This file is part of Astar.
+
+// Copyright (C) 2019-2023 Stake Technologies Pte.Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Astar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Astar is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Astar. If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub mod weights;
+
+use nfts_chain_extension_types::{select_origin, Origin, Outcome};
+use frame_support::traits::{
+    fungibles::approvals::Inspect as ApprovalInspect,
+    fungibles::metadata::Inspect as MetadataInspect,
+};
+use frame_system::RawOrigin;
+use pallet_assets::WeightInfo;
+use pallet_contracts::chain_extension::{
+    ChainExtension, Environment, Ext, InitState, RetVal, SysConfig,
+};
+use parity_scale_codec::Encode;
+use sp_runtime::traits::StaticLookup;
+use sp_runtime::DispatchError;
+use sp_std::marker::PhantomData;
+use sp_std::vec::Vec;
+
+enum NftsFunc {
+    Create,
+    Transfer,
+    Mint,
+    Redeposit,
+    Burn,
+    Destroy,
+    ApproveTransfer,
+    CancelApproval,
+    Freeze,
+    Thaw,
+    FreezeCollection,
+    ThawCollection,
+    TransferOwnership,
+    SetTeam,
+    SetAttribute,
+    ClearAttribute,
+    SetMetadata,
+    ClearMetadata,
+    SetCollectionMetadata,
+    ClearCollectionMetadata,
+    Collection,
+    OwnershipAcceptance,
+    Account,
+    CollectionAccount,
+    Item,
+    CollectionMetadataOf,
+    ItemMetadataOf,
+    Attribute,
+    ItemPriceOf,
+    CollectionMaxSupply,
+}
+
+impl TryFrom<u16> for NftsFunc {
+    type Error = DispatchError;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(NftsFunc::Create),
+            2 => Ok(NftsFunc::Transfer),
+            3 => Ok(NftsFunc::Mint),
+            4 => Ok(NftsFunc::Redeposit),
+            5 => Ok(NftsFunc::Burn),
+            6 => Ok(NftsFunc::Destroy),
+            7 => Ok(NftsFunc::ApproveTransfer),
+            8 => Ok(NftsFunc::CancelApproval),
+            9 => Ok(NftsFunc::Freeze),
+            10 => Ok(NftsFunc::Thaw),
+            11 => Ok(NftsFunc::FreezeCollection),
+            12 => Ok(NftsFunc::ThawCollection),
+            13 => Ok(NftsFunc::TransferOwnership),
+            14 => Ok(NftsFunc::SetTeam),
+            15 => Ok(NftsFunc::SetAttribute),
+            16 => Ok(NftsFunc::ClearAttribute),
+            17 => Ok(NftsFunc::SetMetadata),
+            18 => Ok(NftsFunc::ClearMetadata),
+            19 => Ok(NftsFunc::SetCollectionMetadata),
+            20 => Ok(NftsFunc::ClearCollectionMetadata),
+            21 => Ok(NftsFunc::Collection),
+            22 => Ok(NftsFunc::OwnershipAcceptance),
+            23 => Ok(NftsFunc::Account),
+            24 => Ok(NftsFunc::CollectionAccount),
+            25 => Ok(NftsFunc::Item),
+            26 => Ok(NftsFunc::CollectionMetadataOf),
+            27 => Ok(NftsFunc::ItemMetadataOf),
+            28 => Ok(NftsFunc::Attribute),
+            29 => Ok(NftsFunc::ItemPriceOf),
+            30 => Ok(NftsFunc::CollectionMaxSupply),
+            _ => Err(DispatchError::Other("Unimplemented func_id for NftsFunc")),
+        }
+    }
+}
+
+/*
+/// Pallet Assets chain extension.
+pub struct AssetsExtension<T, W>(PhantomData<(T, W)>);
+
+impl<T, W> Default for AssetsExtension<T, W> {
+    fn default() -> Self {
+        AssetsExtension(PhantomData)
+    }
+}
+
+impl<T, W> ChainExtension<T> for AssetsExtension<T, W>
+where
+    T: pallet_assets::Config + pallet_contracts::Config,
+    <T as pallet_assets::Config>::AssetId: Copy,
+    <<T as SysConfig>::Lookup as StaticLookup>::Source: From<<T as SysConfig>::AccountId>,
+    <T as SysConfig>::AccountId: From<[u8; 32]>,
+    W: weights::WeightInfo,
+{
+    fn call<E: Ext>(&mut self, env: Environment<E, InitState>) -> Result<RetVal, DispatchError>
+    where
+        E: Ext<T = T>,
+    {
+        let func_id = env.func_id().try_into()?;
+        let mut env = env.buf_in_buf_out();
+
+        match func_id {
+            AssetsFunc::Create => {
+                let (origin, id, admin, min_balance): (
+                    Origin,
+                    <T as pallet_assets::Config>::AssetId,
+                    T::AccountId,
+                    T::Balance,
+                ) = env.read_as()?;
+
+                let base_weight = <T as pallet_assets::Config>::WeightInfo::create();
+                env.charge_weight(base_weight)?;
+
+                let raw_origin = select_origin!(&origin, env.ext().address().clone());
+
+                let call_result = pallet_assets::Pallet::<T>::create(
+                    raw_origin.into(),
+                    id.into(),
+                    admin.into(),
+                    min_balance,
+                );
+                return match call_result {
+                    Err(e) => {
+                        let mapped_error = Outcome::from(e);
+                        Ok(RetVal::Converging(mapped_error as u32))
+                    }
+                    Ok(_) => Ok(RetVal::Converging(Outcome::Success as u32)),
+                };
+            }
+            AssetsFunc::Transfer => {
+                let (origin, id, target, amount): (
+                    Origin,
+                    <T as pallet_assets::Config>::AssetId,
+                    T::AccountId,
+                    T::Balance,
+                ) = env.read_as()?;
+
+                let base_weight = <T as pallet_assets::Config>::WeightInfo::transfer();
+                env.charge_weight(base_weight)?;
+
+                let raw_origin = select_origin!(&origin, env.ext().address().clone());
+
+                let call_result = pallet_assets::Pallet::<T>::transfer(
+                    raw_origin.into(),
+                    id.into(),
+                    target.into(),
+                    amount,
+                );
+                return match call_result {
+                    Err(e) => {
+                        let mapped_error = Outcome::from(e);
+                        Ok(RetVal::Converging(mapped_error as u32))
+                    }
+                    Ok(_) => Ok(RetVal::Converging(Outcome::Success as u32)),
+                };
+            }
+            AssetsFunc::Mint => {
+                let (origin, id, beneficiary, amount): (
+                    Origin,
+                    <T as pallet_assets::Config>::AssetId,
+                    T::AccountId,
+                    T::Balance,
+                ) = env.read_as()?;
+
+                let base_weight = <T as pallet_assets::Config>::WeightInfo::mint();
+                env.charge_weight(base_weight)?;
+
+                let raw_origin = select_origin!(&origin, env.ext().address().clone());
+
+                let call_result = pallet_assets::Pallet::<T>::mint(
+                    raw_origin.into(),
+                    id.into(),
+                    beneficiary.into(),
+                    amount,
+                );
+                return match call_result {
+                    Err(e) => {
+                        let mapped_error = Outcome::from(e);
+                        Ok(RetVal::Converging(mapped_error as u32))
+                    }
+                    Ok(_) => Ok(RetVal::Converging(Outcome::Success as u32)),
+                };
+            }
+            AssetsFunc::Burn => {
+                let (origin, id, who, amount): (
+                    Origin,
+                    <T as pallet_assets::Config>::AssetId,
+                    T::AccountId,
+                    T::Balance,
+                ) = env.read_as()?;
+
+                let base_weight = <T as pallet_assets::Config>::WeightInfo::burn();
+                env.charge_weight(base_weight)?;
+
+                let raw_origin = select_origin!(&origin, env.ext().address().clone());
+
+                let call_result = pallet_assets::Pallet::<T>::burn(
+                    raw_origin.into(),
+                    id.into(),
+                    who.into(),
+                    amount,
+                );
+                return match call_result {
+                    Err(e) => {
+                        let mapped_error = Outcome::from(e);
+                        Ok(RetVal::Converging(mapped_error as u32))
+                    }
+                    Ok(_) => Ok(RetVal::Converging(Outcome::Success as u32)),
+                };
+            }
+            AssetsFunc::BalanceOf => {
+                let (id, who): (<T as pallet_assets::Config>::AssetId, T::AccountId) =
+                    env.read_as()?;
+
+                let base_weight = <W as weights::WeightInfo>::balance_of();
+                env.charge_weight(base_weight)?;
+
+                let balance = pallet_assets::Pallet::<T>::balance(id, who);
+                env.write(&balance.encode(), false, None)?;
+            }
+            AssetsFunc::TotalSupply => {
+                let id: <T as pallet_assets::Config>::AssetId = env.read_as()?;
+
+                let base_weight = <W as weights::WeightInfo>::total_supply();
+                env.charge_weight(base_weight)?;
+
+                let total_supply = pallet_assets::Pallet::<T>::total_supply(id);
+                env.write(&total_supply.encode(), false, None)?;
+            }
+            AssetsFunc::Allowance => {
+                let (id, owner, delegate): (
+                    <T as pallet_assets::Config>::AssetId,
+                    T::AccountId,
+                    T::AccountId,
+                ) = env.read_as()?;
+
+                let base_weight = <W as weights::WeightInfo>::allowance();
+                env.charge_weight(base_weight)?;
+
+                let allowance = pallet_assets::Pallet::<T>::allowance(id, &owner, &delegate);
+                env.write(&allowance.encode(), false, None)?;
+            }
+            AssetsFunc::ApproveTransfer => {
+                let (origin, id, delegate, amount): (
+                    Origin,
+                    <T as pallet_assets::Config>::AssetId,
+                    T::AccountId,
+                    T::Balance,
+                ) = env.read_as()?;
+
+                let base_weight = <T as pallet_assets::Config>::WeightInfo::approve_transfer();
+                env.charge_weight(base_weight)?;
+
+                let raw_origin = select_origin!(&origin, env.ext().address().clone());
+
+                let call_result = pallet_assets::Pallet::<T>::approve_transfer(
+                    raw_origin.into(),
+                    id.into(),
+                    delegate.into(),
+                    amount,
+                );
+                return match call_result {
+                    Err(e) => {
+                        let mapped_error = Outcome::from(e);
+                        Ok(RetVal::Converging(mapped_error as u32))
+                    }
+                    Ok(_) => Ok(RetVal::Converging(Outcome::Success as u32)),
+                };
+            }
+            AssetsFunc::CancelApproval => {
+                let (origin, id, delegate): (
+                    Origin,
+                    <T as pallet_assets::Config>::AssetId,
+                    T::AccountId,
+                ) = env.read_as()?;
+
+                let base_weight = <T as pallet_assets::Config>::WeightInfo::cancel_approval();
+                env.charge_weight(base_weight)?;
+
+                let raw_origin = select_origin!(&origin, env.ext().address().clone());
+
+                let call_result = pallet_assets::Pallet::<T>::cancel_approval(
+                    raw_origin.into(),
+                    id.into(),
+                    delegate.into(),
+                );
+                return match call_result {
+                    Err(e) => {
+                        let mapped_error = Outcome::from(e);
+                        Ok(RetVal::Converging(mapped_error as u32))
+                    }
+                    Ok(_) => Ok(RetVal::Converging(Outcome::Success as u32)),
+                };
+            }
+            AssetsFunc::TransferApproved => {
+                let (origin, id, owner, destination, amount): (
+                    Origin,
+                    <T as pallet_assets::Config>::AssetId,
+                    T::AccountId,
+                    T::AccountId,
+                    T::Balance,
+                ) = env.read_as()?;
+
+                let base_weight = <T as pallet_assets::Config>::WeightInfo::transfer_approved();
+                env.charge_weight(base_weight)?;
+
+                let raw_origin = select_origin!(&origin, env.ext().address().clone());
+
+                let call_result = pallet_assets::Pallet::<T>::transfer_approved(
+                    raw_origin.into(),
+                    id.into(),
+                    owner.into(),
+                    destination.into(),
+                    amount,
+                );
+                return match call_result {
+                    Err(e) => {
+                        let mapped_error = Outcome::from(e);
+                        Ok(RetVal::Converging(mapped_error as u32))
+                    }
+                    Ok(_) => Ok(RetVal::Converging(Outcome::Success as u32)),
+                };
+            }
+            AssetsFunc::SetMetadata => {
+                let (origin, id, name, symbol, decimals): (
+                    Origin,
+                    <T as pallet_assets::Config>::AssetId,
+                    Vec<u8>,
+                    Vec<u8>,
+                    u8,
+                ) = env.read_as_unbounded(env.in_len())?;
+
+                let base_weight = <T as pallet_assets::Config>::WeightInfo::set_metadata(
+                    name.len() as u32,
+                    symbol.len() as u32,
+                );
+                env.charge_weight(base_weight)?;
+
+                let raw_origin = select_origin!(&origin, env.ext().address().clone());
+
+                let call_result = pallet_assets::Pallet::<T>::set_metadata(
+                    raw_origin.into(),
+                    id.into(),
+                    name,
+                    symbol,
+                    decimals,
+                );
+                return match call_result {
+                    Err(e) => {
+                        let mapped_error = Outcome::from(e);
+                        Ok(RetVal::Converging(mapped_error as u32))
+                    }
+                    Ok(_) => Ok(RetVal::Converging(Outcome::Success as u32)),
+                };
+            }
+            AssetsFunc::MetadataName => {
+                let id: <T as pallet_assets::Config>::AssetId = env.read_as()?;
+
+                let base_weight = <W as weights::WeightInfo>::metadata_name();
+                env.charge_weight(base_weight)?;
+
+                let name = pallet_assets::Pallet::<T>::name(id);
+                env.write(&name.encode(), false, None)?;
+            }
+            AssetsFunc::MetadataSymbol => {
+                let id: <T as pallet_assets::Config>::AssetId = env.read_as()?;
+
+                let base_weight = <W as weights::WeightInfo>::metadata_symbol();
+                env.charge_weight(base_weight)?;
+
+                let symbol = pallet_assets::Pallet::<T>::symbol(id);
+                env.write(&symbol.encode(), false, None)?;
+            }
+            AssetsFunc::MetadataDecimals => {
+                let id: <T as pallet_assets::Config>::AssetId = env.read_as()?;
+
+                let base_weight = <W as weights::WeightInfo>::metadata_decimals();
+                env.charge_weight(base_weight)?;
+
+                let decimals = pallet_assets::Pallet::<T>::decimals(id);
+                env.write(&decimals.encode(), false, None)?;
+            }
+            AssetsFunc::TransferOwnership => {
+                let (origin, id, owner): (
+                    Origin,
+                    <T as pallet_assets::Config>::AssetId,
+                    T::AccountId,
+                ) = env.read_as()?;
+
+                let base_weight = <T as pallet_assets::Config>::WeightInfo::transfer_ownership();
+                env.charge_weight(base_weight)?;
+
+                let raw_origin = select_origin!(&origin, env.ext().address().clone());
+
+                let call_result = pallet_assets::Pallet::<T>::transfer_ownership(
+                    raw_origin.into(),
+                    id.into(),
+                    owner.into(),
+                );
+                return match call_result {
+                    Err(e) => {
+                        let mapped_error = Outcome::from(e);
+                        Ok(RetVal::Converging(mapped_error as u32))
+                    }
+                    Ok(_) => Ok(RetVal::Converging(Outcome::Success as u32)),
+                };
+            }
+        }
+
+        Ok(RetVal::Converging(Outcome::Success as u32))
+    }
+}
+*/

--- a/chain-extensions/pallet-nfts/src/lib.rs
+++ b/chain-extensions/pallet-nfts/src/lib.rs
@@ -26,7 +26,7 @@ use nfts_chain_extension_types::{select_origin, Origin, Outcome};
 use pallet_contracts::chain_extension::{
     ChainExtension, Environment, Ext, InitState, RetVal, SysConfig,
 };
-use pallet_uniques::DestroyWitness;
+use pallet_uniques::{DestroyWitness, WeightInfo};
 use parity_scale_codec::Encode;
 use sp_runtime::traits::StaticLookup;
 use sp_runtime::BoundedVec;
@@ -142,6 +142,9 @@ where
                     T::AccountId,
                 ) = env.read_as()?;
 
+                let base_weight = <T as pallet_uniques::Config>::WeightInfo::create();
+                env.charge_weight(base_weight)?;
+
                 let raw_origin = select_origin!(&origin, env.ext().address().clone());
 
                 let call_result = pallet_uniques::Pallet::<T>::create(
@@ -164,6 +167,13 @@ where
                     <T as pallet_uniques::Config>::CollectionId,
                     DestroyWitness,
                 ) = env.read_as()?;
+
+                let base_weight = <T as pallet_uniques::Config>::WeightInfo::destroy(
+                    witness.items,
+                    witness.item_metadatas,
+			        witness.attributes,
+                );
+                env.charge_weight(base_weight)?;
 
                 let raw_origin = select_origin!(&origin, env.ext().address().clone());
 
@@ -188,6 +198,9 @@ where
                     <T as pallet_uniques::Config>::ItemId,
                     T::AccountId,
                 ) = env.read_as()?;
+
+                let base_weight = <T as pallet_uniques::Config>::WeightInfo::transfer();
+                env.charge_weight(base_weight)?;
 
                 let raw_origin = select_origin!(&origin, env.ext().address().clone());
 
@@ -214,6 +227,9 @@ where
                     T::AccountId,
                 ) = env.read_as()?;
 
+                let base_weight = <T as pallet_uniques::Config>::WeightInfo::mint();
+                env.charge_weight(base_weight)?;
+
                 let raw_origin = select_origin!(&origin, env.ext().address().clone());
 
                 let call_result = pallet_uniques::Pallet::<T>::mint(
@@ -238,6 +254,9 @@ where
                     <T as pallet_uniques::Config>::ItemId,
                     Option<T::AccountId>,
                 ) = env.read_as()?;
+
+                let base_weight = <T as pallet_uniques::Config>::WeightInfo::burn();
+                env.charge_weight(base_weight)?;
 
                 let raw_origin = select_origin!(&origin, env.ext().address().clone());
 
@@ -264,6 +283,9 @@ where
                     Vec<<T as pallet_uniques::Config>::ItemId>,
                 ) = env.read_as_unbounded(env.in_len())?;
 
+                let base_weight = <T as pallet_uniques::Config>::WeightInfo::redeposit(items.len() as u32);
+                env.charge_weight(base_weight)?;
+
                 let raw_origin = select_origin!(&origin, env.ext().address().clone());
 
                 let call_result = pallet_uniques::Pallet::<T>::redeposit(
@@ -286,6 +308,9 @@ where
                     <T as pallet_uniques::Config>::CollectionId,
                     <T as pallet_uniques::Config>::ItemId,
                 ) = env.read_as()?;
+
+                let base_weight = <T as pallet_uniques::Config>::WeightInfo::freeze();
+                env.charge_weight(base_weight)?;
 
                 let raw_origin = select_origin!(&origin, env.ext().address().clone());
 
@@ -310,6 +335,9 @@ where
                     <T as pallet_uniques::Config>::ItemId,
                 ) = env.read_as()?;
 
+                let base_weight = <T as pallet_uniques::Config>::WeightInfo::thaw();
+                env.charge_weight(base_weight)?;
+
                 let raw_origin = select_origin!(&origin, env.ext().address().clone());
 
                 let call_result = pallet_uniques::Pallet::<T>::thaw(
@@ -330,6 +358,9 @@ where
                 let (origin, collection_id): (Origin, <T as pallet_uniques::Config>::CollectionId) =
                     env.read_as()?;
 
+                let base_weight = <T as pallet_uniques::Config>::WeightInfo::freeze_collection();
+                env.charge_weight(base_weight)?;
+
                 let raw_origin = select_origin!(&origin, env.ext().address().clone());
 
                 let call_result = pallet_uniques::Pallet::<T>::freeze_collection(
@@ -348,6 +379,9 @@ where
             NftsFunc::ThawCollection => {
                 let (origin, collection_id): (Origin, <T as pallet_uniques::Config>::CollectionId) =
                     env.read_as()?;
+
+                let base_weight = <T as pallet_uniques::Config>::WeightInfo::thaw_collection();
+                env.charge_weight(base_weight)?;
 
                 let raw_origin = select_origin!(&origin, env.ext().address().clone());
 
@@ -370,6 +404,9 @@ where
                     <T as pallet_uniques::Config>::CollectionId,
                     T::AccountId,
                 ) = env.read_as()?;
+
+                let base_weight = <T as pallet_uniques::Config>::WeightInfo::transfer_ownership();
+                env.charge_weight(base_weight)?;
 
                 let raw_origin = select_origin!(&origin, env.ext().address().clone());
 
@@ -395,6 +432,9 @@ where
                     T::AccountId,
                     T::AccountId,
                 ) = env.read_as()?;
+
+                let base_weight = <T as pallet_uniques::Config>::WeightInfo::set_team();
+                env.charge_weight(base_weight)?;
 
                 let raw_origin = select_origin!(&origin, env.ext().address().clone());
 
@@ -422,6 +462,9 @@ where
                     T::AccountId,
                 ) = env.read_as()?;
 
+                let base_weight = <T as pallet_uniques::Config>::WeightInfo::approve_transfer();
+                env.charge_weight(base_weight)?;
+
                 let raw_origin = select_origin!(&origin, env.ext().address().clone());
 
                 let call_result = pallet_uniques::Pallet::<T>::approve_transfer(
@@ -446,6 +489,9 @@ where
                     <T as pallet_uniques::Config>::ItemId,
                     Option<T::AccountId>,
                 ) = env.read_as()?;
+
+                let base_weight = <T as pallet_uniques::Config>::WeightInfo::cancel_approval();
+                env.charge_weight(base_weight)?;
 
                 let raw_origin = select_origin!(&origin, env.ext().address().clone());
 
@@ -475,6 +521,9 @@ where
                     BoundedVec<u8, <T as pallet_uniques::Config>::ValueLimit>,
                 ) = env.read_as()?;
 
+                let base_weight = <T as pallet_uniques::Config>::WeightInfo::set_attribute();
+                env.charge_weight(base_weight)?;
+
                 let raw_origin = select_origin!(&origin, env.ext().address().clone());
 
                 let call_result = pallet_uniques::Pallet::<T>::set_attribute(
@@ -500,6 +549,9 @@ where
                     Option<<T as pallet_uniques::Config>::ItemId>,
                     BoundedVec<u8, <T as pallet_uniques::Config>::KeyLimit>,
                 ) = env.read_as()?;
+
+                let base_weight = <T as pallet_uniques::Config>::WeightInfo::clear_attribute();
+                env.charge_weight(base_weight)?;
 
                 let raw_origin = select_origin!(&origin, env.ext().address().clone());
 
@@ -527,6 +579,9 @@ where
                     bool,
                 ) = env.read_as()?;
 
+                let base_weight = <T as pallet_uniques::Config>::WeightInfo::set_metadata();
+                env.charge_weight(base_weight)?;
+
                 let raw_origin = select_origin!(&origin, env.ext().address().clone());
 
                 let call_result = pallet_uniques::Pallet::<T>::set_metadata(
@@ -552,6 +607,9 @@ where
                     <T as pallet_uniques::Config>::ItemId,
                 ) = env.read_as()?;
 
+                let base_weight = <T as pallet_uniques::Config>::WeightInfo::clear_metadata();
+                env.charge_weight(base_weight)?;
+
                 let raw_origin = select_origin!(&origin, env.ext().address().clone());
 
                 let call_result = pallet_uniques::Pallet::<T>::clear_metadata(
@@ -576,6 +634,9 @@ where
                     bool,
                 ) = env.read_as()?;
 
+                let base_weight = <T as pallet_uniques::Config>::WeightInfo::set_collection_metadata();
+                env.charge_weight(base_weight)?;
+
                 let raw_origin = select_origin!(&origin, env.ext().address().clone());
 
                 let call_result = pallet_uniques::Pallet::<T>::set_collection_metadata(
@@ -598,6 +659,9 @@ where
                     Origin,
                     Option<<T as pallet_uniques::Config>::CollectionId>,
                 ) = env.read_as()?;
+
+                let base_weight = <T as pallet_uniques::Config>::WeightInfo::set_accept_ownership();
+                env.charge_weight(base_weight)?;
 
                 let raw_origin = select_origin!(&origin, env.ext().address().clone());
 

--- a/chain-extensions/pallet-nfts/src/weights.rs
+++ b/chain-extensions/pallet-nfts/src/weights.rs
@@ -25,38 +25,53 @@ use sp_std::marker::PhantomData;
 
 /// Weight functions needed for pallet-assets chain-extension.
 pub trait WeightInfo {
-    fn balance_of() -> Weight;
-    fn total_supply() -> Weight;
-    fn allowance() -> Weight;
-    fn metadata_name() -> Weight;
-    fn metadata_symbol() -> Weight;
-    fn metadata_decimals() -> Weight;
+    fn owner() -> Weight;
+    fn collection_owner() -> Weight;
+    fn attribute() -> Weight;
+    fn collection_attribute() -> Weight;
+    fn can_transfer() -> Weight;
+    fn collections(n: u32) -> Weight;
+    fn items(n: u32) -> Weight;
+    fn owned(n: u32) -> Weight;
+    fn owned_in_collection(n: u32) -> Weight;
 }
 
-/// Weights for pallet-assets chain-extension
+/// Weights for pallet-uniques chain-extension
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
-    fn balance_of() -> Weight {
+    fn owner() -> Weight {
         T::DbWeight::get().reads(1 as u64)
     }
 
-    fn total_supply() -> Weight {
+    fn collection_owner() -> Weight {
         T::DbWeight::get().reads(1 as u64)
     }
 
-    fn allowance() -> Weight {
+    fn attribute() -> Weight {
         T::DbWeight::get().reads(1 as u64)
     }
 
-    fn metadata_name() -> Weight {
+    fn collection_attribute() -> Weight {
         T::DbWeight::get().reads(1 as u64)
     }
 
-    fn metadata_symbol() -> Weight {
+    fn can_transfer() -> Weight {
         T::DbWeight::get().reads(1 as u64)
     }
 
-    fn metadata_decimals() -> Weight {
-        T::DbWeight::get().reads(1 as u64)
+    fn collections(n: u32) -> Weight {
+        T::DbWeight::get().reads(1 as u64).saturating_mul(n.into())
+    }
+
+    fn items(n: u32) -> Weight {
+        T::DbWeight::get().reads(1 as u64).saturating_mul(n.into())
+    }
+
+    fn owned(n: u32) -> Weight {
+        T::DbWeight::get().reads(1 as u64).saturating_mul(n.into())
+    }
+
+    fn owned_in_collection(n: u32) -> Weight {
+        T::DbWeight::get().reads(1 as u64).saturating_mul(n.into())
     }
 }

--- a/chain-extensions/pallet-nfts/src/weights.rs
+++ b/chain-extensions/pallet-nfts/src/weights.rs
@@ -1,0 +1,62 @@
+// This file is part of Astar.
+
+// Copyright (C) 2019-2023 Stake Technologies Pte.Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Astar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Astar is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Astar. If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg_attr(rustfmt, rustfmt_skip)]
+#![allow(unused_parens)]
+#![allow(unused_imports)]
+
+use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use sp_std::marker::PhantomData;
+
+/// Weight functions needed for pallet-assets chain-extension.
+pub trait WeightInfo {
+    fn balance_of() -> Weight;
+    fn total_supply() -> Weight;
+    fn allowance() -> Weight;
+    fn metadata_name() -> Weight;
+    fn metadata_symbol() -> Weight;
+    fn metadata_decimals() -> Weight;
+}
+
+/// Weights for pallet-assets chain-extension
+pub struct SubstrateWeight<T>(PhantomData<T>);
+impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
+    fn balance_of() -> Weight {
+        T::DbWeight::get().reads(1 as u64)
+    }
+
+    fn total_supply() -> Weight {
+        T::DbWeight::get().reads(1 as u64)
+    }
+
+    fn allowance() -> Weight {
+        T::DbWeight::get().reads(1 as u64)
+    }
+
+    fn metadata_name() -> Weight {
+        T::DbWeight::get().reads(1 as u64)
+    }
+
+    fn metadata_symbol() -> Weight {
+        T::DbWeight::get().reads(1 as u64)
+    }
+
+    fn metadata_decimals() -> Weight {
+        T::DbWeight::get().reads(1 as u64)
+    }
+}

--- a/chain-extensions/types/nfts/Cargo.toml
+++ b/chain-extensions/types/nfts/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "nfts-chain-extension-types"
+version = "0.1.0"
+license = "Apache-2.0"
+description = "Types definitions for assets chain-extension"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
+
+frame-system = { workspace = true }
+pallet-contracts = { workspace = true }
+sp-runtime = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+	"scale-info/std",
+	"parity-scale-codec/std",
+	"pallet-contracts/std",
+	"sp-runtime/std",
+	"frame-system/std",
+]

--- a/chain-extensions/types/nfts/src/lib.rs
+++ b/chain-extensions/types/nfts/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 use parity_scale_codec::MaxEncodedLen;
 use parity_scale_codec::{Decode, Encode};
-use sp_runtime::{DispatchError, ModuleError};
+use sp_runtime::{traits::Printable, DispatchError, DispatchErrorWithPostInfo, ModuleError};
 
 #[derive(PartialEq, Eq, Copy, Clone, Encode, Decode, Debug)]
 #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
@@ -77,6 +77,14 @@ impl From<DispatchError> for Outcome {
             Some("BidTooLow") => Outcome::BidTooLow,
             _ => Outcome::RuntimeError,
         };
+    }
+}
+
+impl<Info: Eq + PartialEq + Clone + Copy + Encode + Decode + Printable>
+    From<DispatchErrorWithPostInfo<Info>> for Outcome
+{
+    fn from(input: DispatchErrorWithPostInfo<Info>) -> Self {
+        input.error.into()
     }
 }
 

--- a/chain-extensions/types/nfts/src/lib.rs
+++ b/chain-extensions/types/nfts/src/lib.rs
@@ -1,0 +1,104 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+use parity_scale_codec::MaxEncodedLen;
+use parity_scale_codec::{Decode, Encode};
+use sp_runtime::{DispatchError, ModuleError};
+
+#[derive(PartialEq, Eq, Copy, Clone, Encode, Decode, Debug)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum Outcome {
+    /// Success
+    Success = 0,
+    /// The signing account has no permission to do the operation.
+    NoPermission = 1,
+    /// The given item ID is unknown.
+    UnknownCollection = 2,
+    /// The item ID has already been used for an item.
+    AlreadyExists = 3,
+    /// The owner turned out to be different to what was expected.
+    WrongOwner = 4,
+    /// Invalid witness data given.
+    BadWitness = 5,
+    /// The item ID is already taken.
+    InUse = 6,
+    /// The item or collection is frozen.
+    Frozen = 7,
+    /// The delegate turned out to be different to what was expected.
+    WrongDelegate = 8,
+    /// There is no delegate approved.
+    NoDelegate = 9,
+    /// No approval exists that would allow the transfer.
+    Unapproved = 10,
+    /// The named owner has not signed ownership of the collection is acceptable.
+    Unaccepted = 11,
+    /// The item is locked.
+    Locked = 12,
+    /// All items have been minted.
+    MaxSupplyReached = 13,
+    /// The max supply has already been set.
+    MaxSupplyAlreadySet = 14,
+    /// The provided max supply is less than the amount of items a collection already has.
+    MaxSupplyTooSmall = 15,
+    /// The given item ID is unknown.
+    UnknownItem = 16,
+    /// Item is not for sale.
+    NotForSale = 17,
+    /// The provided bid is too low.
+    BidTooLow = 18,
+    /// Origin Caller is not supported
+    OriginCannotBeCaller = 98,
+    /// Unknown error
+    RuntimeError = 99,
+}
+
+impl From<DispatchError> for Outcome {
+    fn from(input: DispatchError) -> Self {
+        let error_text = match input {
+            DispatchError::Module(ModuleError { message, .. }) => message,
+            _ => Some("No module error Info"),
+        };
+        return match error_text {
+            Some("NoPermission") => Outcome::NoPermission,
+            Some("UnknownCollection") => Outcome::UnknownCollection,
+            Some("AlreadyExists") => Outcome::AlreadyExists,
+            Some("WrongOwner") => Outcome::WrongOwner,
+            Some("BadWitness") => Outcome::BadWitness,
+            Some("InUse") => Outcome::InUse,
+            Some("Frozen") => Outcome::Frozen,
+            Some("WrongDelegate") => Outcome::WrongDelegate,
+            Some("NoDelegate") => Outcome::NoDelegate,
+            Some("Unapproved") => Outcome::Unapproved,
+            Some("Unaccepted") => Outcome::Unaccepted,
+            Some("Locked") => Outcome::Locked,
+            Some("MaxSupplyReached") => Outcome::MaxSupplyReached,
+            Some("MaxSupplyAlreadySet") => Outcome::MaxSupplyAlreadySet,
+            Some("MaxSupplyTooSmall") => Outcome::MaxSupplyTooSmall,
+            Some("UnknownItem") => Outcome::UnknownItem,
+            Some("NotForSale") => Outcome::NotForSale,
+            Some("BidTooLow") => Outcome::BidTooLow,
+            _ => Outcome::RuntimeError,
+        };
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Encode, Decode, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum Origin {
+    Caller,
+    Address,
+}
+
+impl Default for Origin {
+    fn default() -> Self {
+        Self::Address
+    }
+}
+
+#[macro_export]
+macro_rules! select_origin {
+    ($origin:expr, $account:expr) => {
+        match $origin {
+            Origin::Caller => return Ok(RetVal::Converging(Outcome::OriginCannotBeCaller as u32)),
+            Origin::Address => RawOrigin::Signed($account),
+        }
+    };
+}


### PR DESCRIPTION
the xcRegions contract will need to have access to a basic underlying NFT pallet.

From our perspective, we will only need access to a very few, most basic calls. However, this PR implements all the calls that are part of pallet_uniques since it is the most basic 'standard' NFT pallet, and having all of its features can be useful.

TODOs:
- [x] Implement inspect calls  
- [x] Charge weight