### PR TITLE
View-Only chain extension for `pallet-uniques`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7507,6 +7507,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-chain-extension-uniques"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "log",
+ "num-traits",
+ "pallet-contracts",
+ "pallet-contracts-primitives",
+ "pallet-uniques",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+ "uniques-chain-extension-types",
+]
+
+[[package]]
 name = "pallet-chain-extension-xvm"
 version = "0.1.1"
 dependencies = [
@@ -15395,6 +15414,16 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-runtime",
+]
+
+[[package]]
+name = "uniques-chain-extension-types"
+version = "0.1.0"
+dependencies = [
+ "frame-system",
+ "pallet-contracts",
+ "parity-scale-codec",
+ "scale-info",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6030,6 +6030,7 @@ dependencies = [
  "pallet-block-rewards-hybrid",
  "pallet-chain-extension-assets",
  "pallet-chain-extension-unified-accounts",
+ "pallet-chain-extension-uniques",
  "pallet-chain-extension-xvm",
  "pallet-collective",
  "pallet-contracts",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13208,6 +13208,7 @@ dependencies = [
  "pallet-balances",
  "pallet-chain-extension-assets",
  "pallet-chain-extension-unified-accounts",
+ "pallet-chain-extension-uniques",
  "pallet-chain-extension-xvm",
  "pallet-collator-selection",
  "pallet-collective",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
 	"chain-extensions/pallet-assets",
 	"chain-extensions/xvm",
 	"chain-extensions/unified-accounts",
+	"chain-extensions/pallet-uniques",
 	"chain-extensions/types/*",
 
 	"vendor/evm-tracing",
@@ -301,10 +302,12 @@ pallet-evm-precompile-unified-accounts = { path = "./precompiles/unified-account
 pallet-chain-extension-xvm = { path = "./chain-extensions/xvm", default-features = false }
 pallet-chain-extension-assets = { path = "./chain-extensions/pallet-assets", default-features = false }
 pallet-chain-extension-unified-accounts = { path = "./chain-extensions/unified-accounts", default-features = false }
+pallet-chain-extension-uniques = { path = "./chain-extensions/pallet-uniques", default-features = false }
 
 xvm-chain-extension-types = { path = "./chain-extensions/types/xvm", default-features = false }
 assets-chain-extension-types = { path = "./chain-extensions/types/assets", default-features = false }
 unified-accounts-chain-extension-types = { path = "./chain-extensions/types/unified-accounts", default-features = false }
+uniques-chain-extension-types = { path = "./chain-extensions/types/uniques", default-features = false }
 
 precompile-utils = { path = "./precompiles/utils", default-features = false }
 

--- a/chain-extensions/pallet-uniques/Cargo.toml
+++ b/chain-extensions/pallet-uniques/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pallet-chain-extension-uniques"
 version = "0.1.0"
 license = "Apache-2.0"
-description = "Assets chain extension for WASM contracts"
+description = "Uniques chain extension for WASM contracts"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/chain-extensions/pallet-uniques/Cargo.toml
+++ b/chain-extensions/pallet-uniques/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "pallet-chain-extension-uniques"
+version = "0.1.0"
+license = "Apache-2.0"
+description = "Assets chain extension for WASM contracts"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+uniques-chain-extension-types = { workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+log = { workspace = true }
+num-traits = { workspace = true }
+pallet-uniques = { workspace = true }
+pallet-contracts = { workspace = true }
+pallet-contracts-primitives = { workspace = true }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
+sp-core = { workspace = true }
+sp-runtime = { workspace = true }
+sp-std = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+	"parity-scale-codec/std",
+	"frame-support/std",
+	"frame-system/std",
+	"num-traits/std",
+	"pallet-contracts/std",
+	"pallet-contracts-primitives/std",
+	"scale-info/std",
+	"sp-std/std",
+	"sp-core/std",
+	"sp-runtime/std",
+	"pallet-uniques/std",
+	"uniques-chain-extension-types/std",
+]

--- a/chain-extensions/pallet-uniques/src/lib.rs
+++ b/chain-extensions/pallet-uniques/src/lib.rs
@@ -1,0 +1,211 @@
+// This file is part of Astar.
+
+// Copyright (C) 2019-2023 Stake Technologies Pte.Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Astar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Astar is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Astar. If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub mod weights;
+
+use frame_support::traits::nonfungibles::{Inspect, InspectEnumerable};
+use pallet_contracts::chain_extension::{
+    ChainExtension, Environment, Ext, InitState, RetVal, SysConfig,
+};
+use parity_scale_codec::Encode;
+use sp_runtime::traits::StaticLookup;
+use sp_runtime::BoundedVec;
+use sp_runtime::DispatchError;
+use sp_std::marker::PhantomData;
+use sp_std::vec::Vec;
+use uniques_chain_extension_types::Outcome;
+
+type AccountIdLookup<T> = <<T as SysConfig>::Lookup as StaticLookup>::Source;
+
+enum UniquesFunc {
+    Owner,
+    CollectionOwner,
+    Attribute,
+    CollectionAttribute,
+    CanTransfer,
+    Collections,
+    Items,
+    Owned,
+    OwnedInCollection,
+}
+
+impl TryFrom<u16> for UniquesFunc {
+    type Error = DispatchError;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(UniquesFunc::Owner),
+            2 => Ok(UniquesFunc::CollectionOwner),
+            3 => Ok(UniquesFunc::Attribute),
+            4 => Ok(UniquesFunc::CollectionAttribute),
+            5 => Ok(UniquesFunc::CanTransfer),
+            6 => Ok(UniquesFunc::Collections),
+            7 => Ok(UniquesFunc::Items),
+            8 => Ok(UniquesFunc::Owned),
+            9 => Ok(UniquesFunc::OwnedInCollection),
+            _ => Err(DispatchError::Other(
+                "Unimplemented func_id for UniquesFunc",
+            )),
+        }
+    }
+}
+
+/// Pallet Uniques chain extension.
+pub struct UniquesExtension<T, W>(PhantomData<(T, W)>);
+
+impl<T, W> Default for UniquesExtension<T, W> {
+    fn default() -> Self {
+        UniquesExtension(PhantomData)
+    }
+}
+
+impl<T, W> ChainExtension<T> for UniquesExtension<T, W>
+where
+    T: pallet_uniques::Config + pallet_contracts::Config,
+    AccountIdLookup<T>: From<<T as SysConfig>::AccountId>,
+    <T as SysConfig>::AccountId: From<[u8; 32]>,
+    W: weights::WeightInfo,
+{
+    fn call<E: Ext>(&mut self, env: Environment<E, InitState>) -> Result<RetVal, DispatchError>
+    where
+        E: Ext<T = T>,
+    {
+        let func_id = env.func_id().try_into()?;
+        let mut env = env.buf_in_buf_out();
+
+        match func_id {
+            UniquesFunc::Owner => {
+                let (collection_id, item): (
+                    <T as pallet_uniques::Config>::CollectionId,
+                    <T as pallet_uniques::Config>::ItemId,
+                ) = env.read_as()?;
+
+                let base_weight = <W as weights::WeightInfo>::owner();
+                env.charge_weight(base_weight)?;
+
+                let owner = pallet_uniques::Pallet::<T>::owner(collection_id, item);
+                env.write(&owner.encode(), false, None)?;
+            }
+            UniquesFunc::CollectionOwner => {
+                let collection_id: <T as pallet_uniques::Config>::CollectionId = env.read_as()?;
+
+                let base_weight = <W as weights::WeightInfo>::collection_owner();
+                env.charge_weight(base_weight)?;
+
+                let owner = pallet_uniques::Pallet::<T>::collection_owner(collection_id);
+                env.write(&owner.encode(), false, None)?;
+            }
+            UniquesFunc::Attribute => {
+                let (collection_id, item, key): (
+                    <T as pallet_uniques::Config>::CollectionId,
+                    <T as pallet_uniques::Config>::ItemId,
+                    BoundedVec<u8, <T as pallet_uniques::Config>::KeyLimit>,
+                ) = env.read_as()?;
+
+                let base_weight = <W as weights::WeightInfo>::attribute();
+                env.charge_weight(base_weight)?;
+
+                let attribute = pallet_uniques::Pallet::<T>::attribute(&collection_id, &item, &key);
+                env.write(&attribute.encode(), false, None)?;
+            }
+            UniquesFunc::CollectionAttribute => {
+                let (collection_id, key): (
+                    <T as pallet_uniques::Config>::CollectionId,
+                    BoundedVec<u8, <T as pallet_uniques::Config>::KeyLimit>,
+                ) = env.read_as()?;
+
+                let base_weight = <W as weights::WeightInfo>::collection_attribute();
+                env.charge_weight(base_weight)?;
+
+                let attribute =
+                    pallet_uniques::Pallet::<T>::collection_attribute(&collection_id, &key);
+                env.write(&attribute.encode(), false, None)?;
+            }
+            UniquesFunc::CanTransfer => {
+                let (collection_id, item): (
+                    <T as pallet_uniques::Config>::CollectionId,
+                    <T as pallet_uniques::Config>::ItemId,
+                ) = env.read_as()?;
+
+                let base_weight = <W as weights::WeightInfo>::can_transfer();
+                env.charge_weight(base_weight)?;
+
+                let can_transfer = pallet_uniques::Pallet::<T>::can_transfer(&collection_id, &item);
+                env.write(&can_transfer.encode(), false, None)?;
+            }
+            UniquesFunc::Collections => {
+                let read_bound: u32 = env.read_as()?;
+
+                let base_weight = <W as weights::WeightInfo>::collections(read_bound);
+                env.charge_weight(base_weight)?;
+
+                let collections: Vec<<T as pallet_uniques::Config>::CollectionId> =
+                    pallet_uniques::Pallet::<T>::collections().collect();
+
+                env.write(&collections.encode(), false, None)?;
+            }
+            UniquesFunc::Items => {
+                let (collection_id, read_bound): (
+                    <T as pallet_uniques::Config>::CollectionId,
+                    u32,
+                ) = env.read_as()?;
+
+                let base_weight = <W as weights::WeightInfo>::items(read_bound);
+                env.charge_weight(base_weight)?;
+
+                let items: Vec<<T as pallet_uniques::Config>::ItemId> =
+                    pallet_uniques::Pallet::<T>::items(&collection_id).collect();
+
+                env.write(&items.encode(), false, None)?;
+            }
+            UniquesFunc::Owned => {
+                let (who, read_bound): (T::AccountId, u32) = env.read_as()?;
+
+                let items: Vec<(
+                    <T as pallet_uniques::Config>::CollectionId,
+                    <T as pallet_uniques::Config>::ItemId,
+                )> = pallet_uniques::Pallet::<T>::owned(&who).collect();
+
+                let base_weight = <W as weights::WeightInfo>::owned(read_bound);
+                env.charge_weight(base_weight)?;
+
+                env.write(&items.encode(), false, None)?;
+            }
+            UniquesFunc::OwnedInCollection => {
+                let (who, collection_id, read_bound): (
+                    T::AccountId,
+                    <T as pallet_uniques::Config>::CollectionId,
+                    u32,
+                ) = env.read_as()?;
+
+                let items: Vec<<T as pallet_uniques::Config>::ItemId> =
+                    pallet_uniques::Pallet::<T>::owned_in_collection(&collection_id, &who)
+                        .collect();
+
+                let base_weight = <W as weights::WeightInfo>::owned_in_collection(read_bound);
+                env.charge_weight(base_weight)?;
+
+                env.write(&items.encode(), false, None)?;
+            }
+        }
+
+        Ok(RetVal::Converging(Outcome::Success as u32))
+    }
+}

--- a/chain-extensions/pallet-uniques/src/weights.rs
+++ b/chain-extensions/pallet-uniques/src/weights.rs
@@ -56,7 +56,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
     }
 
     fn can_transfer() -> Weight {
-        T::DbWeight::get().reads(1 as u64)
+        T::DbWeight::get().reads(2 as u64)
     }
 
     fn collections(n: u32) -> Weight {

--- a/chain-extensions/pallet-uniques/src/weights.rs
+++ b/chain-extensions/pallet-uniques/src/weights.rs
@@ -23,7 +23,7 @@
 use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
 use sp_std::marker::PhantomData;
 
-/// Weight functions needed for pallet-assets chain-extension.
+/// Weight functions needed for pallet-uniques chain-extension.
 pub trait WeightInfo {
     fn owner() -> Weight;
     fn collection_owner() -> Weight;

--- a/chain-extensions/pallet-uniques/src/weights.rs
+++ b/chain-extensions/pallet-uniques/src/weights.rs
@@ -1,0 +1,77 @@
+// This file is part of Astar.
+
+// Copyright (C) 2019-2023 Stake Technologies Pte.Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// Astar is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Astar is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Astar. If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg_attr(rustfmt, rustfmt_skip)]
+#![allow(unused_parens)]
+#![allow(unused_imports)]
+
+use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use sp_std::marker::PhantomData;
+
+/// Weight functions needed for pallet-assets chain-extension.
+pub trait WeightInfo {
+    fn owner() -> Weight;
+    fn collection_owner() -> Weight;
+    fn attribute() -> Weight;
+    fn collection_attribute() -> Weight;
+    fn can_transfer() -> Weight;
+    fn collections(n: u32) -> Weight;
+    fn items(n: u32) -> Weight;
+    fn owned(n: u32) -> Weight;
+    fn owned_in_collection(n: u32) -> Weight;
+}
+
+/// Weights for pallet-uniques chain-extension
+pub struct SubstrateWeight<T>(PhantomData<T>);
+impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
+    fn owner() -> Weight {
+        T::DbWeight::get().reads(1 as u64)
+    }
+
+    fn collection_owner() -> Weight {
+        T::DbWeight::get().reads(1 as u64)
+    }
+
+    fn attribute() -> Weight {
+        T::DbWeight::get().reads(1 as u64)
+    }
+
+    fn collection_attribute() -> Weight {
+        T::DbWeight::get().reads(1 as u64)
+    }
+
+    fn can_transfer() -> Weight {
+        T::DbWeight::get().reads(1 as u64)
+    }
+
+    fn collections(n: u32) -> Weight {
+        T::DbWeight::get().reads(1 as u64).saturating_mul(n.into())
+    }
+
+    fn items(n: u32) -> Weight {
+        T::DbWeight::get().reads(1 as u64).saturating_mul(n.into())
+    }
+
+    fn owned(n: u32) -> Weight {
+        T::DbWeight::get().reads(1 as u64).saturating_mul(n.into())
+    }
+
+    fn owned_in_collection(n: u32) -> Weight {
+        T::DbWeight::get().reads(1 as u64).saturating_mul(n.into())
+    }
+}

--- a/chain-extensions/types/uniques/Cargo.toml
+++ b/chain-extensions/types/uniques/Cargo.toml
@@ -2,7 +2,7 @@
 name = "uniques-chain-extension-types"
 version = "0.1.0"
 license = "Apache-2.0"
-description = "Types definitions for assets chain-extension"
+description = "Types definitions for uniques chain-extension"
 authors.workspace = true
 edition.workspace = true
 homepage.workspace = true

--- a/chain-extensions/types/uniques/Cargo.toml
+++ b/chain-extensions/types/uniques/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "uniques-chain-extension-types"
+version = "0.1.0"
+license = "Apache-2.0"
+description = "Types definitions for assets chain-extension"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
+
+frame-system = { workspace = true }
+pallet-contracts = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+	"scale-info/std",
+	"parity-scale-codec/std",
+	"pallet-contracts/std",
+	"frame-system/std",
+]

--- a/chain-extensions/types/uniques/src/lib.rs
+++ b/chain-extensions/types/uniques/src/lib.rs
@@ -1,0 +1,37 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+use parity_scale_codec::MaxEncodedLen;
+use parity_scale_codec::{Decode, Encode};
+
+#[derive(PartialEq, Eq, Copy, Clone, Encode, Decode, Debug)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum Outcome {
+    /// Success
+    Success = 0,
+    /// Origin Caller is not supported
+    OriginCannotBeCaller = 98,
+    /// Unknown error
+    RuntimeError = 99,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Encode, Decode, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum Origin {
+    Caller,
+    Address,
+}
+
+impl Default for Origin {
+    fn default() -> Self {
+        Self::Address
+    }
+}
+
+#[macro_export]
+macro_rules! select_origin {
+    ($origin:expr, $account:expr) => {
+        match $origin {
+            Origin::Caller => return Ok(RetVal::Converging(Outcome::OriginCannotBeCaller as u32)),
+            Origin::Address => RawOrigin::Signed($account),
+        }
+    };
+}

--- a/runtime/local/Cargo.toml
+++ b/runtime/local/Cargo.toml
@@ -96,6 +96,7 @@ moonbeam-rpc-primitives-txpool = { workspace = true, optional = true }
 
 # chain-extensions
 pallet-chain-extension-assets = { workspace = true }
+pallet-chain-extension-uniques = { workspace = true }
 
 # benchmarking
 array-bytes = { workspace = true }
@@ -184,6 +185,7 @@ std = [
 	"moonbeam-rpc-primitives-txpool/std",
 	"substrate-wasm-builder",
 	"pallet-chain-extension-assets/std",
+	"pallet-chain-extension-uniques/std",
 	"astar-primitives/std",
 ]
 runtime-benchmarks = [

--- a/runtime/local/src/chain_extensions.rs
+++ b/runtime/local/src/chain_extensions.rs
@@ -20,6 +20,7 @@ use super::{Runtime, UnifiedAccounts, Xvm};
 
 /// Registered WASM contracts chain extensions.
 pub use pallet_chain_extension_assets::AssetsExtension;
+pub use pallet_chain_extension_uniques::UniquesExtension;
 use pallet_contracts::chain_extension::RegisteredChainExtension;
 
 pub use pallet_chain_extension_unified_accounts::UnifiedAccountsExtension;
@@ -39,4 +40,10 @@ impl<W: pallet_chain_extension_assets::weights::WeightInfo> RegisteredChainExten
 
 impl RegisteredChainExtension<Runtime> for UnifiedAccountsExtension<Runtime, UnifiedAccounts> {
     const ID: u16 = 03;
+}
+
+impl<W: pallet_chain_extension_uniques::weights::WeightInfo> RegisteredChainExtension<Runtime>
+    for UniquesExtension<Runtime, W>
+{
+    const ID: u16 = 04;
 }

--- a/runtime/local/src/lib.rs
+++ b/runtime/local/src/lib.rs
@@ -930,6 +930,7 @@ impl pallet_contracts::Config for Runtime {
         XvmExtension<Self, Xvm, UnifiedAccounts>,
         AssetsExtension<Self, pallet_chain_extension_assets::weights::SubstrateWeight<Self>>,
         UnifiedAccountsExtension<Self, UnifiedAccounts>,
+        UniquesExtension<Self, pallet_chain_extension_uniques::weights::SubstrateWeight<Self>>,
     );
     type Schedule = Schedule;
     type AddressGenerator = pallet_contracts::DefaultAddressGenerator;

--- a/runtime/shibuya/Cargo.toml
+++ b/runtime/shibuya/Cargo.toml
@@ -130,6 +130,7 @@ moonbeam-rpc-primitives-txpool = { workspace = true, optional = true }
 
 # chain-extensions
 pallet-chain-extension-assets = { workspace = true }
+pallet-chain-extension-uniques = { workspace = true }
 
 # benchmarking
 array-bytes = { workspace = true }
@@ -242,6 +243,7 @@ std = [
 	"xcm-executor/std",
 	"substrate-wasm-builder",
 	"pallet-chain-extension-assets/std",
+	"pallet-chain-extension-uniques/std",
 	"orml-xtokens/std",
 	"orml-xcm-support/std",
 	"astar-primitives/std",

--- a/runtime/shibuya/src/chain_extensions.rs
+++ b/runtime/shibuya/src/chain_extensions.rs
@@ -20,6 +20,7 @@ use super::{Runtime, UnifiedAccounts, Xvm};
 
 /// Registered WASM contracts chain extensions.
 pub use pallet_chain_extension_assets::AssetsExtension;
+pub use pallet_chain_extension_uniques::UniquesExtension;
 use pallet_contracts::chain_extension::RegisteredChainExtension;
 
 pub use pallet_chain_extension_unified_accounts::UnifiedAccountsExtension;
@@ -39,4 +40,10 @@ impl<W: pallet_chain_extension_assets::weights::WeightInfo> RegisteredChainExten
 
 impl RegisteredChainExtension<Runtime> for UnifiedAccountsExtension<Runtime, UnifiedAccounts> {
     const ID: u16 = 03;
+}
+
+impl<W: pallet_chain_extension_uniques::weights::WeightInfo> RegisteredChainExtension<Runtime>
+    for UniquesExtension<Runtime, W>
+{
+    const ID: u16 = 04;
 }

--- a/runtime/shibuya/src/lib.rs
+++ b/runtime/shibuya/src/lib.rs
@@ -719,6 +719,7 @@ impl pallet_contracts::Config for Runtime {
         XvmExtension<Self, Xvm, UnifiedAccounts>,
         AssetsExtension<Self, pallet_chain_extension_assets::weights::SubstrateWeight<Self>>,
         UnifiedAccountsExtension<Self, UnifiedAccounts>,
+        UniquesExtension<Self, pallet_chain_extension_uniques::weights::SubstrateWeight<Self>>,
     );
     type Schedule = Schedule;
     type AddressGenerator = pallet_contracts::DefaultAddressGenerator;


### PR DESCRIPTION
This PR implements a view-only chain extension for the uniques pallet. 

The reason it is view-only is that extrinsics can be called from contracts using `call_runtime`, which is a much more future-proof and less error-prone approach.

TODO: 

- [x] add to shibuya and local runtimes